### PR TITLE
iOS bundle build action: Build bundle without code signing.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,13 +23,15 @@ jobs:
       run: |-
         set -o pipefail
         mkdir output
-        xcodebuild -project InjectionIII.xcodeproj -scheme InjectionIII -derivedDataPath output/ 2>&1 | tee output/build_log.txt
+        xcodebuild CODE_SIGNING_ALLOWED=NO -project InjectionIII.xcodeproj -scheme InjectionIII -config Release 2>&1 | tee output/build_log.txt
+        injection_app_path=$(xcodebuild -config Release -showBuildSettings | grep "CODESIGNING_FOLDER_PATH" | cut -f2 -d'=' | tr -d ' ')
+        rsync -au "$injection_app_path/Contents/Resources/iOSInjection.bundle" output/ 
 
     - name: Upload bundle
       uses: actions/upload-artifact@v2
       with:
         name: iOSInjection.bundle
-        path: output/Build/Products/Release-iphonesimulator/iOSInjection.bundle
+        path: output/iOSInjection.bundle
 
     - name: Upload logs
       if: ${{ always() }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,12 +26,13 @@ jobs:
         xcodebuild CODE_SIGNING_ALLOWED=NO -project InjectionIII.xcodeproj -scheme InjectionIII -config Release 2>&1 | tee output/build_log.txt
         injection_app_path=$(xcodebuild -config Release -showBuildSettings | grep "CODESIGNING_FOLDER_PATH" | cut -f2 -d'=' | tr -d ' ')
         rsync -au "$injection_app_path/Contents/Resources/iOSInjection.bundle" output/ 
+        zip --symlinks -r output/iOSInjection.bundle.zip output/iOSInjection.bundle
 
     - name: Upload bundle
       uses: actions/upload-artifact@v2
       with:
-        name: iOSInjection.bundle
-        path: output/iOSInjection.bundle
+        name: iOSInjection.bundle.zip
+        path: output/iOSInjection.bundle.zip
 
     - name: Upload logs
       if: ${{ always() }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: workflow_dispatch
+on: [workflow_dispatch, pull_request]
 
 jobs:
   build:

--- a/InjectionIII/InjectionIII.entitlements
+++ b/InjectionIII/InjectionIII.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<false/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/InjectionIII/build_bundles.sh
+++ b/InjectionIII/build_bundles.sh
@@ -49,11 +49,6 @@ build_bundle tvOS AppleTVSimulator appletvsimulator &&
 # iphoneos on M1 mac (requires Sandbox switched off)
 #build_bundle maciOS iPhoneOS iphoneos &&
 
-# macOSSwiftUISupport needs to be built separately from the main app
-"$DEVELOPER_BIN_DIR"/xcodebuild SYMROOT=$SYMROOT ARCHS="$ARCHS" -sdk macosx -config $CONFIGURATION -target SwiftUISupport &&
-
-rsync -au $SYMROOT/$CONFIGURATION/macOSSwiftUISupport.bundle "$CODESIGNING_FOLDER_PATH/Contents/Resources" &&
-
 # Copy across bundles and .swiftinterface files
 rsync -au $SYMROOT/$CONFIGURATION/SwiftTrace.framework/Versions/A/{Headers,Modules} "$CODESIGNING_FOLDER_PATH/Contents/Resources/macOSInjection.bundle/Contents/Frameworks/SwiftTrace.framework/Versions/A" &&
 


### PR DESCRIPTION
- build_bundles.sh: Remove unused SwiftUI support build.
- iOS bundle build action: Build bundle without code signing.
